### PR TITLE
minor change on the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEBUG
-            value: "true"
           - name: APP_LABEL
             valueFrom:
               fieldRef:
@@ -213,12 +211,9 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
           resources:
-            limits:
-              cpu: "6"
-              memory: "2Gi"
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The Backend API is an Envoy Gateway extension that allows integration with non-K
 
 ```bash
 helm install eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.4.0 \
+  --version v1.4.1 \
   --set config.envoyGateway.extensionApis.enableBackend=true \
   -n envoy-gateway-system \
   --create-namespace
@@ -57,7 +57,7 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm \
 Deploy a demo app that relies on Kong plugins for traffic processing.
 
 ```bash
-kubectl apply -f https://github.com/envoyproxy/gateway/releases/download/v1.4.0/quickstart.yaml
+kubectl apply -f https://github.com/envoyproxy/gateway/releases/download/v1.4.1/quickstart.yaml
 ```
 
 ## Step 3: Deploy kong2envoy Using kong2eg CLI
@@ -145,7 +145,7 @@ Flags:
       --namespace string      Kubernetes namespace to use for the Envoy Gateway resources. (default "default")
 ```
 
-You can save the output to a file, check the generated resources, tweak them if necessary, and then apply them to the cluster.
+You can save the output to a file, review the generated resources, and make any necessary adjustments—for example, tuning resource requests and limits based on your application’s load—before applying them to the cluster.
 
 ```bash
 kong2eg print --kong-config kong.yaml --namespace default --gateway eg --gatewayclass eg  > kong2eg.yaml

--- a/internal/cmd/kong2eg/templates/demo-kong-config.yaml
+++ b/internal/cmd/kong2eg/templates/demo-kong-config.yaml
@@ -4,6 +4,9 @@ services:
 - name: receiver
   url: http://localhost:16002
   routes:
+  - name: no-op-route # The fallback route for Kong to handle unmatched requests
+    paths:
+    - /
   - name: my-route-0
     hosts:
     - www.example.com:10080

--- a/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
+++ b/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
@@ -129,12 +129,9 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
           resources:
-            limits:
-              cpu: "6"
-              memory: "2Gi"
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
+++ b/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
@@ -115,8 +115,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEBUG
-            value: "true"
           - name: APP_LABEL
             valueFrom:
               fieldRef:

--- a/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
+++ b/internal/cmd/kong2eg/templates/kong2envoy.yaml.tpl
@@ -124,8 +124,6 @@ spec:
             mountPath: /var/sock/kong
           - name: kong-config
             mountPath: /usr/local/share/kong2envoy/
-          - name: podinfo
-            mountPath: /etc/podinfo
           resources:
             requests:
               cpu: 100m
@@ -138,12 +136,6 @@ spec:
           labels:
             app: kong2envoy  # this label is used by kong2envoy to match the ConfigMap that contains the Kong configuration
           volumes:
-            - name: podinfo
-              downwardAPI:
-                items:
-                - path: "labels"
-                  fieldRef:
-                    fieldPath: metadata.labels
             - name: socket-dir
               emptyDir: {}
             - name: kong-config

--- a/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
@@ -146,12 +146,9 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
           resources:
-            limits:
-              cpu: "6"
-              memory: "2Gi"
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
@@ -141,8 +141,6 @@ spec:
             mountPath: /var/sock/kong
           - name: kong-config
             mountPath: /usr/local/share/kong2envoy/
-          - name: podinfo
-            mountPath: /etc/podinfo
           resources:
             requests:
               cpu: 100m
@@ -155,12 +153,6 @@ spec:
           labels:
             app: kong2envoy  # this label is used by kong2envoy to match the ConfigMap that contains the Kong configuration
           volumes:
-            - name: podinfo
-              downwardAPI:
-                items:
-                - path: "labels"
-                  fieldRef:
-                    fieldPath: metadata.labels
             - name: socket-dir
               emptyDir: {}
             - name: kong-config

--- a/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/custom-config.expected.yaml
@@ -132,8 +132,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEBUG
-            value: "true"
           - name: APP_LABEL
             valueFrom:
               fieldRef:

--- a/internal/cmd/kong2eg/testdata/default.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/default.expected.yaml
@@ -166,12 +166,9 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
           resources:
-            limits:
-              cpu: "6"
-              memory: "2Gi"
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/internal/cmd/kong2eg/testdata/default.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/default.expected.yaml
@@ -164,8 +164,6 @@ spec:
             mountPath: /var/sock/kong
           - name: kong-config
             mountPath: /usr/local/share/kong2envoy/
-          - name: podinfo
-            mountPath: /etc/podinfo
           resources:
             requests:
               cpu: 100m
@@ -178,12 +176,6 @@ spec:
           labels:
             app: kong2envoy  # this label is used by kong2envoy to match the ConfigMap that contains the Kong configuration
           volumes:
-            - name: podinfo
-              downwardAPI:
-                items:
-                - path: "labels"
-                  fieldRef:
-                    fieldPath: metadata.labels
             - name: socket-dir
               emptyDir: {}
             - name: kong-config

--- a/internal/cmd/kong2eg/testdata/default.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/default.expected.yaml
@@ -18,6 +18,9 @@ data:
       - name: receiver
         url: http://localhost:16002
         routes:
+        - name: no-op-route # The fallback route for Kong to handle unmatched requests
+          paths:
+          - /
         - name: my-route-0
           hosts:
           - www.example.com:10080
@@ -152,8 +155,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEBUG
-            value: "true"
           - name: APP_LABEL
             valueFrom:
               fieldRef:

--- a/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
@@ -166,12 +166,9 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
           resources:
-            limits:
-              cpu: "6"
-              memory: "2Gi"
             requests:
-              cpu: "6"
-              memory: "2Gi"
+              cpu: 100m
+              memory: 512Mi
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
@@ -164,8 +164,6 @@ spec:
             mountPath: /var/sock/kong
           - name: kong-config
             mountPath: /usr/local/share/kong2envoy/
-          - name: podinfo
-            mountPath: /etc/podinfo
           resources:
             requests:
               cpu: 100m
@@ -178,12 +176,6 @@ spec:
           labels:
             app: kong2envoy  # this label is used by kong2envoy to match the ConfigMap that contains the Kong configuration
           volumes:
-            - name: podinfo
-              downwardAPI:
-                items:
-                - path: "labels"
-                  fieldRef:
-                    fieldPath: metadata.labels
             - name: socket-dir
               emptyDir: {}
             - name: kong-config

--- a/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
+++ b/internal/cmd/kong2eg/testdata/gateway-namespace-mode.expected.yaml
@@ -18,6 +18,9 @@ data:
       - name: receiver
         url: http://localhost:16002
         routes:
+        - name: no-op-route # The fallback route for Kong to handle unmatched requests
+          paths:
+          - /
         - name: my-route-0
           hosts:
           - www.example.com:10080
@@ -152,8 +155,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEBUG
-            value: "true"
           - name: APP_LABEL
             valueFrom:
               fieldRef:


### PR DESCRIPTION
* set the kong2envoy request resource as the same as the envoy default one.
* use the latest Envoy Gateway 1.4.1
* add a note in the README to remind users to adjust the resources as needed.